### PR TITLE
Fix retries

### DIFF
--- a/lib/adapters/bitfinex-adapter.js
+++ b/lib/adapters/bitfinex-adapter.js
@@ -45,18 +45,10 @@ class BitfinexAdapter {
    * @returns {Promise<{authToken: string, expiresAt: number}>}
    */
   async refreshToken () {
-    try {
-      const [authToken] = await this.rest.generateToken(this._generateOptions)
-      const expiresAt = Date.now() + (this._generateOptions.ttl * 1000)
+    const [authToken] = await this.rest.generateToken(this._generateOptions)
+    const expiresAt = Date.now() + (this._generateOptions.ttl * 1000)
 
-      return { authToken, expiresAt }
-    } catch (e) {
-      if (e.message.includes("ERR_TOKEN_CAPS_POLICY_INVALID")) {
-        throw new Error('The given API key does not have the required permissions, please make sure to enable "get" and "create" capacities for "Account", "Orders", and "Wallets"')
-      }
-
-      throw e
-    }
+    return { authToken, expiresAt }
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,13 +4,22 @@ const debug = require('debug')('token:renew:plugin')
 const Try = require('flat-try')
 
 const THRESHOLD = 60 * 60 * 1000 // renew one hour before expiring
+const defaultRetryInterval = 30 * 1000
+const defaultMaxRetries = 3
+
+/**
+ * @typedef {Object} Adapter
+ * @property {function(): Promise<{ authToken: string, expiresAt: number }>} refreshToken
+ */
 
 class TokenRenewalPlugin {
   /**
-   * @param {Object} adapter
-   * @param {function: Promise<{ authToken: string, expiresAt: number }>} adapter.refreshToken
+   * @param {Adapter} adapter
+   * @param {Object} config
+   * @param {number?} config.maxRetries - default 3
+   * @param {number?} config.retryInterval - 30 seconds
    */
-  constructor (adapter) {
+  constructor (adapter, config = {}) {
     this.id = 'renew-token-plugin'
     this.type = 'ws2'
     this.manager = {
@@ -19,6 +28,15 @@ class TokenRenewalPlugin {
     }
     this.algoManagers = new Map()
     this.adapter = adapter
+
+    const {
+      maxRetries = defaultMaxRetries,
+      retryInterval = defaultRetryInterval
+    } = config
+
+    this.retries = 0
+    this.maxRetries = maxRetries
+    this.retryInterval = retryInterval
 
     this._renewAuthToken = this._renewAuthToken.bind(this)
   }
@@ -49,8 +67,7 @@ class TokenRenewalPlugin {
     return state
   }
 
-  _scheduleAutoRenewal (expiresAt = 0) {
-    const timeout = expiresAt - Date.now() - THRESHOLD
+  _scheduleAutoRenewal (timeout = 0) {
     this._timeout = setTimeout(this._renewAuthToken, timeout)
   }
 
@@ -60,14 +77,11 @@ class TokenRenewalPlugin {
     const [err, response] = await Try.promise(() => this.adapter.refreshToken())
 
     if (err) {
-      debug('failed to renew auth token: %j', err)
+      return this._handleError(err)
+    }
 
-      for (const manager of this._getManagersAndCleanReclaimedRefs()) {
-        manager.emit('plugin:error', `[${this.id}] error: ${err.message}`)
-      }
-
-      this._scheduleAutoRenewal()
-      return
+    if (this.retries > 0) {
+      this.retries = 0
     }
 
     const { authToken, expiresAt } = response
@@ -76,7 +90,8 @@ class TokenRenewalPlugin {
       manager.auth({ authToken })
     }
 
-    this._scheduleAutoRenewal(expiresAt)
+    const timeout = expiresAt - Date.now() - THRESHOLD
+    this._scheduleAutoRenewal(timeout)
   }
 
   _getManagersAndCleanReclaimedRefs () {
@@ -100,6 +115,25 @@ class TokenRenewalPlugin {
     if (!this._timeout) return
     clearTimeout(this._timeout)
     this._timeout = undefined
+  }
+
+  _handleError (err) {
+    debug('failed to renew auth token: %j', err)
+
+    this.retries++
+
+    if (this.retries >= this.maxRetries) {
+      return this._notifyError(`[${this.id}] error: max retries exceeded`)
+    }
+
+    this._notifyError(`[${this.id}] error: ${err.message}`)
+    this._scheduleAutoRenewal(this.retryInterval)
+  }
+
+  _notifyError (message) {
+    for (const manager of this._getManagersAndCleanReclaimedRefs()) {
+      manager.emit('plugin:error', message)
+    }
   }
 }
 

--- a/test/adapters/bitfinex-adapter.js
+++ b/test/adapters/bitfinex-adapter.js
@@ -59,17 +59,4 @@ describe('BitfinexAdapter', () => {
     expect(authToken).to.eq(generatedAuthToken)
     expect(expiresAt).to.eq(1338000)
   })
-
-  it('should handle capacity errors', async () => {
-    RestStub.generateToken.rejects(new Error('500 - ["error",null,"ERR_TOKEN_CAPS_POLICY_INVALID"]'))
-
-    const adapter = new BitfinexAdapter(args)
-
-    try {
-      await adapter.refreshToken()
-      assert.fail()
-    } catch (e) {
-      expect(e.message).to.eq('The given API key does not have the required permissions, please make sure to enable "get" and "create" capacities for "Account", "Orders", and "Wallets"')
-    }
-  })
 })


### PR DESCRIPTION
if the adapter fails for any reason, it would automatically reschedule the retry and flood the API with calls