### PR TITLE
Set expires at

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,6 +18,7 @@ class TokenRenewalPlugin {
    * @param {Object} config
    * @param {number?} config.maxRetries - default 3
    * @param {number?} config.retryInterval - 30 seconds
+   * @param {number?} config.expiresAt - default 0
    */
   constructor (adapter, config = {}) {
     this.id = 'renew-token-plugin'
@@ -31,12 +32,14 @@ class TokenRenewalPlugin {
 
     const {
       maxRetries = defaultMaxRetries,
-      retryInterval = defaultRetryInterval
+      retryInterval = defaultRetryInterval,
+      expiresAt = 0
     } = config
 
     this.retries = 0
     this.maxRetries = maxRetries
     this.retryInterval = retryInterval
+    this.expiresAt = expiresAt
 
     this._renewAuthToken = this._renewAuthToken.bind(this)
   }
@@ -67,7 +70,8 @@ class TokenRenewalPlugin {
     return state
   }
 
-  _scheduleAutoRenewal (timeout = 0) {
+  _scheduleAutoRenewal () {
+    const timeout = Math.max(this.expiresAt - Date.now() - THRESHOLD, 0)
     this._timeout = setTimeout(this._renewAuthToken, timeout)
   }
 
@@ -90,8 +94,8 @@ class TokenRenewalPlugin {
       manager.auth({ authToken })
     }
 
-    const timeout = expiresAt - Date.now() - THRESHOLD
-    this._scheduleAutoRenewal(timeout)
+    this.expiresAt = expiresAt
+    this._scheduleAutoRenewal()
   }
 
   _getManagersAndCleanReclaimedRefs () {
@@ -126,8 +130,10 @@ class TokenRenewalPlugin {
       return this._notifyError(`[${this.id}] error: max retries exceeded`)
     }
 
+    this.expiresAt = this.retryInterval + Date.now() + THRESHOLD
+    this._scheduleAutoRenewal()
+
     this._notifyError(`[${this.id}] error: ${err.message}`)
-    this._scheduleAutoRenewal(this.retryInterval)
   }
 
   _notifyError (message) {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -92,14 +92,16 @@ describe('RenewTokenPlugin', () => {
 
     const config = {
       maxRetries: 3,
-      retryInterval: 10
+      retryInterval: 10,
+      expiresAt: 100
     }
     const plugin = new TokenRenewalPlugin(adapter, config)
+    expect(plugin.expiresAt).to.eq(config.expiresAt)
+
     const manager = { emit: sandbox.stub() }
-
     plugin.manager['ws:created']({ id, manager, state })
-    await delay(100)
 
+    await delay(100)
     assert.callCount(adapter.refreshToken, 4)
     assert.calledWithExactly(debugStub, 'failed to renew auth token: %j', fakeErr)
     assert.calledWithExactly(manager.emit, 'plugin:error', '[renew-token-plugin] error: message explaining error')


### PR DESCRIPTION
this allows creating an instance with a known expire time, otherwise, a new token would be immediately generated